### PR TITLE
Add Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+builds:
+  - main: ./cmd/connector/main.go
+    binary: conduit-connector-algolia
+    goos:
+      - darwin
+      - linux
+      - windows
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X 'github.com/conduitio-labs/conduit-connector-algolia.version={{ .Tag }}'"
+checksum:
+  name_template: checksums.txt
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^go.mod:'
+      - '^.github:'
+      - Merge branch

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: build test
 
+VERSION=`git describe --tags --dirty --always`
+
 build:
-	go build -o conduit-connector-algolia cmd/algolia/main.go
+	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-algolia.version=${VERSION}'" -o conduit-connector-algolia cmd/connector/main.go
 
 test:
 	go test $(GOTEST_FLAGS) -race ./...
-

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -10,5 +10,5 @@ func main() {
 		algolia.Specification,
 		nil,
 		algolia.NewDestination,
-		)
+	)
 }

--- a/spec.go
+++ b/spec.go
@@ -1,13 +1,20 @@
 package algolia
 
-import sdk "github.com/conduitio/conduit-connector-sdk"
+import (
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+// version is set during the build process (i.e. the Makefile).
+// It follows Go's convention for module version, where the version
+// starts with the letter v, followed by a semantic version.
+var version = "dev"
 
 func Specification() sdk.Specification {
 	return sdk.Specification{
 		Name:        "algolia",
 		Summary:     "A destination connector for Algolia",
 		Description: "TBD",
-		Version:     "v0.1.0",
+		Version:     version,
 		Author:      "Meroxa, Inc.",
 		DestinationParams: map[string]sdk.Parameter{
 			DestinationConfigAPIKey: {


### PR DESCRIPTION
This PR adds a goreleaser github action which releases the connector when a semantic version tag is pushed.